### PR TITLE
Created vite plugin to display the readable hostname.

### DIFF
--- a/config/vite-plugins/vite-display-network-url-hostname-plugin.ts
+++ b/config/vite-plugins/vite-display-network-url-hostname-plugin.ts
@@ -1,0 +1,28 @@
+import { ViteDevServer, Plugin } from "vite";
+import os from 'os';
+
+export function displayNetworkUrlWithHostnamePlugin(): Plugin {
+    return {
+      name: 'hostname-display',
+      configureServer(server: ViteDevServer) {
+        const isHostFlagEnabled = server.config.server.host === true || server.config.server.host === '0.0.0.0';
+        if(isHostFlagEnabled){
+          const originalPrintUrls = server.printUrls;
+          server.printUrls = () => {
+            originalPrintUrls();
+            const protocol = server.config.server.https ? 'https' : 'http';
+            const hostname = os.hostname();
+            const port = server.config.server.port;
+            const base = server.config.base || '';
+            const networkUrl = `${protocol}://${hostname}:${port}${base}`
+  
+            const green = (text: string) => `\x1b[32m${text}\x1b[0m`;
+            const cyan = (text: string) => `\x1b[36m${text}\x1b[0m`;
+            const bold = (text: string) => `\x1b[1m${text}\x1b[22m`;
+  
+            console.log(`  ${green("➜")}  ${bold("Network (via Hostname):")} ${cyan(networkUrl)}`);
+          };
+        }
+      },
+    };
+  }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
+import process from "node:process";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
-import process from "node:process";
+import { displayNetworkUrlWithHostnamePlugin } from './config/vite-plugins/vite-display-network-url-hostname-plugin';
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -17,6 +18,7 @@ export default defineConfig({
         disable: process.env.SENTRY_PLUGIN_DISABLED == "true"
       }),
       react(),
+      displayNetworkUrlWithHostnamePlugin(),
     ],
     preview: {
       port: 3000,


### PR DESCRIPTION
When using the --host option, there will be another section "Network (via Hostname)" displaying the readable url to the running app.